### PR TITLE
Add studio landing page with consistent styling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -158,6 +158,206 @@
   border-right: 1px solid rgba(0, 0, 0, .1);
 }
 
+/* inner page */
+.header--inner {
+  min-height: 520px;
+  position: relative;
+}
+
+.header--inner .inner-hero {
+  padding-top: 200px;
+  padding-bottom: 120px;
+  max-width: 830px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.header--inner .inner-hero h1 {
+  color: #ffffff;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+.inner-hero__text {
+  color: rgba(255, 255, 255, .85);
+  max-width: 700px;
+}
+
+.content--inner {
+  background-color: #ffffff;
+}
+
+.services-overview {
+  padding-top: 140px;
+  padding-bottom: 120px;
+}
+
+.services-overview__image img {
+  max-width: 320px;
+}
+
+.services-grid {
+  padding-top: 120px;
+  padding-bottom: 120px;
+}
+
+.services-grid__card {
+  background-color: #ffffff;
+  border: 1px solid rgba(0, 0, 0, .08);
+  border-radius: 4px;
+  padding: 50px 35px;
+  height: 100%;
+  box-shadow: 0 20px 50px rgba(12, 24, 33, .08);
+  transition: transform .3s ease, box-shadow .3s ease;
+}
+
+.services-grid__card:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 30px 60px rgba(12, 24, 33, .15);
+}
+
+.services-grid__card h5 {
+  text-transform: uppercase;
+  font-size: 14px;
+  letter-spacing: 1px;
+}
+
+.services-grid__card p {
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.services-grid__icon img {
+  height: 54px;
+}
+
+.approach {
+  padding-top: 140px;
+  padding-bottom: 140px;
+  background: linear-gradient(180deg, rgba(7, 23, 33, .95), rgba(7, 23, 33, .8));
+  color: #ffffff;
+  text-align: center;
+}
+
+.approach p {
+  color: rgba(255, 255, 255, .75);
+}
+
+.approach__list {
+  margin-top: 60px;
+}
+
+.approach__item {
+  padding: 20px 25px;
+}
+
+.approach__item h3 {
+  font-size: 16px;
+  text-transform: uppercase;
+  color: #00e0d0;
+  margin-bottom: 20px;
+}
+
+.case-studies {
+  padding-top: 140px;
+  padding-bottom: 120px;
+}
+
+.case-studies__card {
+  background-color: #ffffff;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 25px 45px rgba(12, 24, 33, .12);
+  transition: transform .3s ease, box-shadow .3s ease;
+  height: 100%;
+}
+
+.case-studies__card:hover {
+  transform: translateY(-12px);
+  box-shadow: 0 35px 65px rgba(12, 24, 33, .18);
+}
+
+.case-studies__body {
+  padding: 30px;
+}
+
+.case-studies__body h5 {
+  text-transform: uppercase;
+  font-size: 15px;
+  letter-spacing: 1px;
+  margin-bottom: 15px;
+}
+
+.case-studies__body p {
+  font-size: 14px;
+  line-height: 1.7;
+  color: rgba(0, 0, 0, .75);
+}
+
+.cta-banner {
+  padding: 80px 0;
+  background: linear-gradient(90deg, rgba(0, 224, 208, .9), rgba(0, 90, 255, .9));
+  color: #ffffff;
+}
+
+.cta-banner h2 {
+  text-transform: uppercase;
+  font-size: 24px;
+  letter-spacing: 1px;
+}
+
+.cta-banner p {
+  margin-bottom: 0;
+}
+
+.cta-banner .btn {
+  color: #ffffff;
+  border-color: #ffffff;
+}
+
+.cta-banner .btn:hover {
+  background-color: #ffffff;
+  color: #008fda;
+}
+
+@media (max-width: 991.98px) {
+  .header--inner .inner-hero {
+    padding-top: 160px;
+    padding-bottom: 100px;
+  }
+
+  .services-overview {
+    text-align: center;
+  }
+
+  .services-overview__image {
+    margin-bottom: 40px;
+    text-align: center !important;
+  }
+
+  .cta-banner {
+    text-align: center;
+  }
+
+  .cta-banner .btn {
+    margin-top: 25px;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .header--inner .inner-hero {
+    padding-top: 140px;
+  }
+
+  .inner-hero__text {
+    font-size: 14px;
+  }
+
+  .approach__item {
+    margin-bottom: 30px;
+  }
+}
+
 .exp-line {
   width: 50px;
   height: 2px;

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <a class="nav-item nav-link" href="#our-works"><strong>Works</strong></a>
             <a class="nav-item nav-link" href="#testimonials"><strong>People Say</strong></a>
             <a class="nav-item nav-link" href="#contact"><strong>Contact</strong></a>
+            <a class="nav-item nav-link" href="studio.html"><strong>Studio</strong></a>
           </div>
         </div>
       </div>

--- a/studio.html
+++ b/studio.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Tajam Studio — Creative Partnerships</title>
+  <!-- google fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
+  <!-- bootstrap -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+    integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+  <!-- icons font -->
+  <link rel="stylesheet" href="fonts/css/font-awesome.min.css">
+  <!-- css -->
+  <link rel="stylesheet" href="css/main.css">
+</head>
+
+<body>
+  <!-- Header -->
+  <header class="header header--inner" id="header">
+    <nav class="navbar fixed-top navbar-expand-lg navbar-light">
+      <div class="container">
+        <a class="navbar-brand" href="index.html"><img src="img/2-layers.png" alt="Logo"></a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup"
+          aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse justify-content-end" id="navbarNavAltMarkup">
+          <div class="navbar-nav">
+            <a class="nav-item nav-link" href="index.html#header"><strong>Home</strong></a>
+            <a class="nav-item nav-link" href="index.html#our-story"><strong>About</strong></a>
+            <a class="nav-item nav-link" href="index.html#expertise"><strong>Expertise</strong></a>
+            <a class="nav-item nav-link" href="index.html#team"><strong>Teams</strong></a>
+            <a class="nav-item nav-link" href="index.html#our-works"><strong>Works</strong></a>
+            <a class="nav-item nav-link" href="index.html#testimonials"><strong>People Say</strong></a>
+            <a class="nav-item nav-link" href="index.html#contact"><strong>Contact</strong></a>
+            <a class="nav-item nav-link active" href="studio.html"><strong>Studio</strong></a>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <div class="inner-hero content-center">
+      <h1>Immersive experiences for bold brands</h1>
+      <div class="line"></div>
+      <p class="inner-hero__text">We transform ambitious ideas into meaningful digital products, guiding every project from the
+        initial spark to launch and beyond. Discover how our studio blends strategy, design and technology to build
+        remarkable journeys.</p>
+      <a class="btn btn-outline-primary mx-auto" href="#overview">Start the tour</a>
+    </div>
+  </header>
+
+  <main class="content content--inner" id="content">
+    <!-- overview -->
+    <section class="our-story services-overview" id="overview">
+      <div class="container">
+        <div class="row align-items-center">
+          <div class="col-md-5 col-sm-12 services-overview__image text-center text-md-right">
+            <img src="img/Replace_with_your_logo.png" alt="Studio" class="img-fluid">
+          </div>
+          <div class="col-md-6 col-sm-12 ml-md-auto">
+            <div class="our-story__block-flex">
+              <h1 class="mb-3">STUDIO DNA</h1>
+              <p>Every collaboration begins with listening. We take the time to understand your audience, uncover
+                opportunities and define the goals that will guide our partnership. Our multidisciplinary team combines
+                design thinking with technical expertise to deliver products that feel effortless and perform brilliantly
+                across every touchpoint.</p>
+              <p class="mb-0">From research and workshops to prototyping and launch, we create transparent roadmaps that keep
+                you informed and inspired at every milestone.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- services grid -->
+    <section class="expertise services-grid" id="capabilities">
+      <div class="container">
+        <div class="row">
+          <div class="col-12 d-flex flex-column align-items-center">
+            <h1>What we craft</h1>
+            <p>Purposeful solutions that shape memorable brands and products</p>
+            <div class="exp-line"></div>
+          </div>
+        </div>
+        <div class="row mt-5">
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="services-grid__card text-center">
+              <div class="services-grid__icon mb-4">
+                <img src="img/11.png" alt="Digital Products">
+              </div>
+              <h5 class="mb-3"><strong>Digital Product Design</strong></h5>
+              <p>We define user journeys, craft intuitive interfaces and produce scalable design systems that evolve with
+                your product.</p>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="services-grid__card text-center">
+              <div class="services-grid__icon mb-4">
+                <img src="img/12.png" alt="Brand Experience">
+              </div>
+              <h5 class="mb-3"><strong>Brand Experience</strong></h5>
+              <p>From naming and narrative to visual expression, we craft cohesive identities that resonate on every
+                platform and drive recognition.</p>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="services-grid__card text-center">
+              <div class="services-grid__icon mb-4">
+                <img src="img/16.png" alt="Engineering">
+              </div>
+              <h5 class="mb-3"><strong>Engineering Partnerships</strong></h5>
+              <p>Our engineers collaborate closely with your team to deliver reliable, performant solutions with clean
+                architecture and maintainable code.</p>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="services-grid__card text-center">
+              <div class="services-grid__icon mb-4">
+                <img src="img/14.png" alt="Growth">
+              </div>
+              <h5 class="mb-3"><strong>Growth & Optimization</strong></h5>
+              <p>We continuously test, measure and refine digital products to improve retention, conversion and overall
+                customer delight.</p>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="services-grid__card text-center">
+              <div class="services-grid__icon mb-4">
+                <img src="img/13.png" alt="Immersive Media">
+              </div>
+              <h5 class="mb-3"><strong>Immersive Media</strong></h5>
+              <p>Interactive installations, AR storytelling and cinematic motion graphics that pull audiences into your
+                narrative.</p>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="services-grid__card text-center">
+              <div class="services-grid__icon mb-4">
+                <img src="img/15.png" alt="Support">
+              </div>
+              <h5 class="mb-3"><strong>Launch Support</strong></h5>
+              <p>Training, documentation and campaign assets ensure your team can share the story and scale the product
+                with confidence.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- approach -->
+    <section class="approach" id="process">
+      <div class="container">
+        <div class="row">
+          <div class="col-12 d-flex flex-column align-items-center">
+            <h1>Our collaborative rhythm</h1>
+            <p>Every engagement is anchored by clear communication and measurable progress</p>
+            <div class="exp-line"></div>
+          </div>
+        </div>
+        <div class="row approach__list">
+          <div class="col-md-3 col-sm-6 approach__item">
+            <h3>Discover</h3>
+            <p>We immerse ourselves in your world, interviewing stakeholders and analysing insights to uncover impactful
+              opportunities.</p>
+          </div>
+          <div class="col-md-3 col-sm-6 approach__item">
+            <h3>Define</h3>
+            <p>Together we prioritise initiatives, align success metrics and shape a roadmap that keeps everyone moving in
+              sync.</p>
+          </div>
+          <div class="col-md-3 col-sm-6 approach__item">
+            <h3>Design</h3>
+            <p>Rapid prototyping and iterative feedback loops translate ideas into delightful experiences grounded in real
+              user needs.</p>
+          </div>
+          <div class="col-md-3 col-sm-6 approach__item">
+            <h3>Deliver</h3>
+            <p>With an eye on quality and performance, we ship resilient solutions, support launch and monitor impact after
+              release.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- case studies -->
+    <section class="case-studies" id="case-studies">
+      <div class="container">
+        <div class="row">
+          <div class="col-12 d-flex flex-column align-items-center">
+            <h1>Featured collaborations</h1>
+            <p>A glimpse at the partnerships that keep us inspired</p>
+            <div class="exp-line"></div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="case-studies__card">
+              <img src="img/Sire.png" alt="Voyager" class="img-fluid">
+              <div class="case-studies__body">
+                <h5>Voyager Airlines</h5>
+                <p>Designing a unified booking journey across mobile and kiosk platforms boosted conversions by 34%.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="case-studies__card">
+              <img src="img/TemnoSire.png" alt="Halo" class="img-fluid">
+              <div class="case-studies__body">
+                <h5>Halo Health</h5>
+                <p>We built an intuitive telehealth experience that connects specialists and patients within seconds.</p>
+              </div>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 mb-4">
+            <div class="case-studies__card">
+              <img src="img/Sire.png" alt="Aurora" class="img-fluid">
+              <div class="case-studies__body">
+                <h5>Aurora Labs</h5>
+                <p>A flexible design system empowered the internal team to scale new product lines in half the time.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- call to action -->
+    <section class="cta-banner" id="collaborate">
+      <div class="container">
+        <div class="row align-items-center">
+          <div class="col-lg-8 col-md-7">
+            <h2>Ready to shape what comes next?</h2>
+            <p>Tell us about your vision and we will assemble the perfect team to bring it to life.</p>
+          </div>
+          <div class="col-lg-4 col-md-5 text-md-right text-center">
+            <a href="mailto:hello@tajamstudio.com" class="btn btn-outline-primary">Let’s collaborate</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- footer -->
+  <footer class="footer pb-5" id="footer">
+    <div class="container">
+      <div class="row">
+        <div class="footer__flex col-lg-4">
+          <div class="footer__block-logo">
+            <a href="index.html">
+              <img src="img/2-layers.png" alt="logo">
+            </a>
+          </div>
+          <p class="footer__text mt-4">
+            lorem quis bibendum auctor,
+            nisi elit consequat ipsum, nec
+            sagittis sem nibh elit.
+            Duis sed odio sit amet
+            auctror a ornare odio non mauris
+            vitae erat in elit
+          </p>
+        </div>
+        <div class="footer__flex col-lg-4">
+          <h1 class="footer__titles mb-lg-5"> <strong>OUR STUDIO</strong> </h1>
+          <div class="footer__about-us d-flex">
+            <div class="icon-nav mr-3">
+              <img src="img/nav.png" alt="">
+            </div>
+            <p class="footer__text">
+              Ruko cucruk, Jl. Radio luar
+              dalem jos No.12 - 13,
+              Kalideres - Jakarta Barat
+              11480 - Indonesia
+            </p>
+          </div>
+          <div class="footer__phone d-flex">
+            <div class="icon-phone mr-3">
+              <img src="img/tell.png" alt="">
+            </div>
+            <p class="footer__text">
+              +38(050)-010-22-14
+            </p>
+          </div>
+        </div>
+        <div class="footer__flex col-lg-4">
+          <h1 class="footer__titles mb-5"><strong>STAY IN TOUCH</strong></h1>
+          <div class="footer-send-message d-flex">
+            <input class="footer__input px-2 mr-2" type="text" placeholder="Subscribe our newsletter">
+            <button class="tellegram"><img src="img/telega.png" alt="send"></button>
+          </div>
+          <div class="footer__icons d-flex justify-content-between mt-4">
+            <i class="fa fa-facebook fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-twitter fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-dribbble fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-instagram fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-google-plus fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-youtube-play fa-2x" aria-hidden="true"></i>
+          </div>
+        </div>
+      </div>
+      <div class="row mt-5">
+        <div class="col-lg-5 footer__links">
+          <a href="#">HELP</a>
+          <a href="#">TERMS & CONDITION</a>
+          <a href="#" class="mr-0">PRIVACY</a>
+        </div>
+        <div class="col-lg-4 footer__copyright ml-lg-auto">
+          <p class="footer__text mb-0">Copyright © 2018 - Likhovskyi Dima.</p>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <!-- add bootstrap -->
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+    integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+    integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  <!-- add js -->
+  <script src="js/script.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- create a new studio.html inner page that follows the existing branding with hero, service, approach, and case study sections
- extend the shared stylesheet with reusable inner-page components and responsive tweaks
- link to the studio page from the homepage navigation for easy discovery

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de4f6594a08321bca20c78aacd3f87